### PR TITLE
docs: list all supported RUNTIME_DB_TYPE values in zh quick start

### DIFF
--- a/docs/zh/1. 快速开始.md
+++ b/docs/zh/1. 快速开始.md
@@ -15,7 +15,7 @@ Agent Runtime 首版本主要支持低码方式的 Agent 发布：与 openJiuwen
 
 请参考 [配置说明](<2. 配置说明.md>) 创建并编辑 `.env` 配置文件，按需调整运行参数，核心配置项如下，重点包括：
 
-- `RUNTIME_DB_TYPE`：支持 `mysql` 和 `sqlite`
+- `RUNTIME_DB_TYPE`：支持 `mysql`、`sqlite`、`gaussdb` 和 `opengauss`
 - 将`MODE`的值改成`product`
 - 其他运行时相关参数（如ip地址、端口号等）
 


### PR DESCRIPTION
Paired: [GitHub #124](https://github.com/openJiuwen-ai/agent-runtime/pull/124) ↔ [GitCode !475](https://gitcode.com/openJiuwen/agent-runtime/merge_requests/475)

## 问题 / Problem

`docs/zh/1. 快速开始.md` 第 18 行写着 `RUNTIME_DB_TYPE` 只支持 `mysql` 和 `sqlite`，与代码和仓库内其余所有文档不一致。

Line 18 of `docs/zh/1. 快速开始.md` states that `RUNTIME_DB_TYPE` supports only `mysql` and `sqlite`, which contradicts both the source code and every other document in this repository.

## 证据 / Evidence

| 来源 Source | 内容 Content |
|---|---|
| `applications/lowcode_agent/openjiuwen_runtime/examples/lowcode_agent/lowcode_agent_runner.py:44` | `_VALID_DB_TYPES = {"mysql", "sqlite", "gaussdb", "opengauss"}` |
| `docs/zh/1. 快速开始.md:43`（同一文件） | 支持 `mysql`、`sqlite`、`gaussdb` 和 `opengauss` |
| `docs/zh/2. 配置说明.md:11` | 支持 mysql、sqlite、gaussdb、opengauss 四个可选值 |
| `docs/en/1. Quick Start.md:18` | `mysql`, `sqlite`, `gaussdb`, or `opengauss` |
| `README.md:95` / `README_zh.md:95` | 四个值均列出 / all four values listed |
| `docs/zh/1. 快速开始.md:18`（修改前） | ❌ 仅 `mysql` 和 `sqlite` / only `mysql` and `sqlite` |

同一份中文快速开始文档内部就自相矛盾（第 18 行 vs 第 43 行），而且第 46–50 行紧接着还给出了 `gaussdb` / `opengauss` 的可选依赖安装说明。读者按第 18 行理解会误以为 Runtime 不支持 GaussDB / openGauss。

The file contradicts itself (line 18 vs. line 43), and lines 46–50 immediately below even explain how to install the `async-gaussdb` optional dependency for `gaussdb` / `opengauss`. A reader stopping at line 18 would wrongly conclude that GaussDB / openGauss is unsupported.

## 修改 / Change

仅一处文字修改，与同文件第 43 行的写法保持一致。No functional change — one wording fix, aligned with line 43 of the same file.

```diff
-- `RUNTIME_DB_TYPE`：支持 `mysql` 和 `sqlite`
+- `RUNTIME_DB_TYPE`：支持 `mysql`、`sqlite`、`gaussdb` 和 `opengauss`
```

## 验证 / How to verify

```bash
sed -n '44p' applications/lowcode_agent/openjiuwen_runtime/examples/lowcode_agent/lowcode_agent_runner.py
sed -n '18p;43p' "docs/zh/1. 快速开始.md"
```
